### PR TITLE
Support capability "Audio Notification"

### DIFF
--- a/devicetypes/tonesto7/echo-speaks-device.src/echo-speaks-device.groovy
+++ b/devicetypes/tonesto7/echo-speaks-device.src/echo-speaks-device.groovy
@@ -31,6 +31,7 @@ metadata {
         capability "Music Player"
         capability "Notification"
         capability "Speech Synthesis"
+	capability "Audio Notification"
 
         attribute "lastUpdated", "string"
         attribute "deviceStatus", "string"


### PR DESCRIPTION
Devices like the Sonos still use capability Audio Notification, so SmartApps supporting those devices won't work with this DTH without this capability.
The methods for this capability are already implemented (playText, playTextAndResume)