### PR TITLE
Added "audioTrackData" attribute

### DIFF
--- a/devicetypes/tonesto7/echo-speaks-device.src/echo-speaks-device.groovy
+++ b/devicetypes/tonesto7/echo-speaks-device.src/echo-speaks-device.groovy
@@ -64,6 +64,7 @@ metadata {
         attribute "wakeWords", "enum"
         attribute "wifiNetwork", "string"
         attribute "wasLastSpokenToDevice", "string"
+	  attribute "audioTrackData", "JSON_OBJECT"    
 
         command "playText", ["string"] //This command is deprecated in ST but will work
         command "playTextAndResume"


### PR DESCRIPTION
Added "audioTrackData" attribute so SmartThings users don't have to uncomment the "Audio Track Data" capability manually to use SharpTools Album Art feature. Now both ST and HE users can use this DTH without manual change.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes
Added "audioTrackData" attribute.
<!--- Describe your changes in detail -->

## Reason for Change
To support SharpTools.io Album Art feature without having to manually uncomment the "Audio Track Data" capability.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on Echo Gen1 with SharpTools.io dashboard.
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
