### PR TITLE
Added audioTrackData attribute to support SharpTools Album Art

### DIFF
--- a/drivers/echo-speaks-device.groovy
+++ b/drivers/echo-speaks-device.groovy
@@ -23,7 +23,7 @@ metadata {
     definition (name: "Echo Speaks Device", namespace: "tonesto7", author: "Anthony Santilli", importUrl: "https://raw.githubusercontent.com/tonesto7/echo-speaks/master/drivers/echo-speaks-device.groovy") {
         // capability "Audio Mute" // Not Compatible with Hubitat
         capability "Audio Notification"
-        // capability "Audio Track Data" // To support SharpTools.io Album Art feature
+        // capability "Audio Track Data" // Not Compatible with Hubitat
         capability "Audio Volume"
         capability "Music Player"
         capability "Notification"
@@ -63,6 +63,8 @@ metadata {
         attribute "wakeWords", "enum"
         attribute "wifiNetwork", "string"
         attribute "wasLastSpokenToDevice", "string"
+	    
+	attribute "audioTrackData", "JSON_OBJECT" // To support SharpTools.io Album Art feature
 
         command "playText", ["string"] //This command is deprecated in ST but will work
         command "playTextAndResume"


### PR DESCRIPTION
Added "audioTrackData" attribute to support the Album Art Feature in SharpTools.io for the Hubitat users. The event sent to "audioTrackData" has been previously added, so we just need to add "audioTrackData" as an attribute. (Hubitat doesn't support Audio Track Data capability.)

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes
Added "audioTrackData" attribute.
<!--- Describe your changes in detail -->

## Reason for Change
To support SharpTools.io Album Art feature for Hubitat users.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested with Echo Dot (1st gen) and Echo (1st gen) with Hubitat and v3.3.0.1 device driver. The audioTrackData attribute is updated in Hubitat as expected.

<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
