### PR TITLE
Fixed online status check for TTS

### DIFF
--- a/drivers/echo-speaks-device.groovy
+++ b/drivers/echo-speaks-device.groovy
@@ -2692,7 +2692,7 @@ void speechTest(String ttsMsg=sNULL) {
 void parallelSpeak(String msg) {
     logTrace("parallelSpeak() command received...")
     if(!msg) { logWarn("No Message sent with parallelSpeak(${fixLg(msg)}) command", true) }
-    else {
+    else if(isCommandTypeAllowed("TTS")) {
         if(isZone()) {
             parent.relaySpeakZone(parent.id.toString(), msg, true)
             String lastMsg = msg ?: "Nothing to Show Here..."
@@ -2749,9 +2749,6 @@ void updateLevel(oldvolume, newvolume) {
 
 private void speechCmd(Map cmdMap=[:], Boolean parallel=false) {
     if(!cmdMap) { logError("speechCmd | Error | cmdMap is missing"); return }
-    String healthStatus = getHealthStatus()
-    if(!(healthStatus in ["ACTIVE", "ONLINE"])) { logWarn("speechCmd Ignored... Device is OFFLINE", true); return }
-
     if(settings.logTrace){
         String tr = "speechCmd (${cmdMap.cmdDesc}) | Msg: ${fixLg(cmdMap.message.toString())}"
         tr += cmdMap.newVolume ? " | SetVolume: (${cmdMap.newVolume})" :sBLANK

--- a/drivers/echo-speaks-device.groovy
+++ b/drivers/echo-speaks-device.groovy
@@ -258,12 +258,6 @@ Map getEchoDevInfo(String cmd) {
    return null
 }
 
-String getHealthStatus(Boolean lower=false) {
-    String res = device?.getStatus()
-    if(lower) { return res?.toLowerCase() }
-    return res
-}
-
 String getShortDevName(){
     return device?.displayName?.replace("Echo - ", sBLANK)
 }

--- a/drivers/echo-speaks-zone-device.groovy
+++ b/drivers/echo-speaks-zone-device.groovy
@@ -2692,7 +2692,7 @@ void speechTest(String ttsMsg=sNULL) {
 void parallelSpeak(String msg) {
     logTrace("parallelSpeak() command received...")
     if(!msg) { logWarn("No Message sent with parallelSpeak(${fixLg(msg)}) command", true) }
-    else {
+    else if(isCommandTypeAllowed("TTS")) {
         if(isZone()) {
             parent.relaySpeakZone(parent.id.toString(), msg, true)
             String lastMsg = msg ?: "Nothing to Show Here..."
@@ -2749,9 +2749,6 @@ void updateLevel(oldvolume, newvolume) {
 
 private void speechCmd(Map cmdMap=[:], Boolean parallel=false) {
     if(!cmdMap) { logError("speechCmd | Error | cmdMap is missing"); return }
-    String healthStatus = getHealthStatus()
-    if(!(healthStatus in ["ACTIVE", "ONLINE"])) { logWarn("speechCmd Ignored... Device is OFFLINE", true); return }
-
     if(settings.logTrace){
         String tr = "speechCmd (${cmdMap.cmdDesc}) | Msg: ${fixLg(cmdMap.message.toString())}"
         tr += cmdMap.newVolume ? " | SetVolume: (${cmdMap.newVolume})" :sBLANK

--- a/drivers/echo-speaks-zone-device.groovy
+++ b/drivers/echo-speaks-zone-device.groovy
@@ -258,12 +258,6 @@ Map getEchoDevInfo(String cmd) {
    return null
 }
 
-String getHealthStatus(Boolean lower=false) {
-    String res = device?.getStatus()
-    if(lower) { return res?.toLowerCase() }
-    return res
-}
-
 String getShortDevName(){
     return device?.displayName?.replace("Echo - ", sBLANK)
 }


### PR DESCRIPTION
Bug: Getting "speechCmd Ignored... Device is OFFLINE" message even when the device was online.
Fix: I noticed two different ways of checking whether the device was online.  One seemed like it was only used by the TTS methods, so I removed that one and consolidated.